### PR TITLE
Use proxy if set in ENV.

### DIFF
--- a/lib/asana/config.rb
+++ b/lib/asana/config.rb
@@ -13,6 +13,7 @@ module Asana
     def configure
       yield self
       Resource.site      = DEFAULT_ENDPOINT
+      Resource.proxy     = ENV['https_proxy'] if ENV['https_proxy']
       Resource.user      = self.api_key
       Resource.password  = ''
       Resource.format    = :json


### PR DESCRIPTION
If the https_proxy value is set in the environment, set ActiveResource to use it.
